### PR TITLE
Align names with the latest generic draft

### DIFF
--- a/draft-irtf-cfrg-concrete-hybrid-kems.md
+++ b/draft-irtf-cfrg-concrete-hybrid-kems.md
@@ -307,16 +307,16 @@ output, so it is appropriate for use in hybrid KEMs with `Nss = 32`.
 
 This section instantiates the following concrete KEMs:
 
-GC-MP256:
+MLKEM768-P256:
 : A hybrid KEM composing ML-KEM-768 and P-256 using the GC framework, with
   SHAKE256 as the PRG and SHA3-256 as the KDF.
 
-GC-MX25519:
+MLKEM768-X25519:
 : A hybrid KEM composing ML-KEM-768 and Curve25519 using the GC framework, with
   SHAKE256 as the PRG and SHA3-256 as the KDF. This construction is identical
   to the X-Wing construction in {{XWING-SPEC}}.
 
-GC-MP384:
+MLKEM1024-P384:
 : A hybrid KEM composing ML-KEM-1024 and P-384 using the GC framework, with
   SHAKE256 as the PRG and SHA3-256 as the KDF.
 


### PR DESCRIPTION
The latest generic draft defines frameworks along Group/KEM and Universal/C2PRI axes.  All of the instantiations in this doc use a Group for the T component, and the C2PRI-assuming combiner, thus the GC framework.

The names are intended to be compact but mnemonic: `<framework>-<PQ><T>`.  I have only included a number (~security level) for the T part because it seemed sufficient.