### PR TITLE
Remove ASCII labels

### DIFF
--- a/draft-irtf-cfrg-concrete-hybrid-kems.md
+++ b/draft-irtf-cfrg-concrete-hybrid-kems.md
@@ -370,7 +370,7 @@ This hybrid KEM combines ML-KEM-768 with P-256 using the CG framework from
 * `KEM_PQ`: ML-KEM-768 {{mlkem}}
 * `PRG`: SHAKE-256 {{FIPS202}}
 * `KDF`: SHA3-256 {{FIPS202}}
-* `Label`: `|-()-|` (0x7C2D28292D7C)
+* `Label`: 0x7C2D28292D7C
 
 The KEM constants for the resulting hybrid KEM are as follows:
 
@@ -390,7 +390,7 @@ It has the following components:
 * `Group_T`: Curve25519 {{group-curve25519}}
 * `PRG`: SHAKE-256 {{FIPS202}}
 * `KDF`: SHA3-256 {{FIPS202}}
-* `Label`: `\.//^\` (0x5C2E2F2F5E5C)
+* `Label`: 0x5C2E2F2F5E5C
 
 The following constants for the hybrid KEM are also defined:
 
@@ -409,7 +409,7 @@ This hybrid KEM combines ML-KEM-1024 with P-384 using the CG framework from
 * `KEM_PQ`: ML-KEM-1024 {{mlkem}}
 * `PRG`: SHAKE-256 {{FIPS202}}
 * `KDF`: SHA3-256 {{FIPS202}}
-* `Label`: ` \| /-\` (0x207C202F2D5C)
+* `Label`: 0x207C202F2D5C
 
 The following constants for the hybrid KEM are also defined:
 
@@ -452,11 +452,11 @@ The components used in this document meet these requirements:
 This document requests that the following values be added to the "Hybrid KEM
 Labels" registry:
 
-| Label      | Fw | PQ Component | T Component | KDF      | PRG       | Nseed | Nss | Reference |
-|============|====|==============|=============|==========|===========|=======|=====|===========|
-| "\|-()-\|" | CG | ML-KEM-768   | P-256       | SHA3-256 | SHAKE-256 | 32    | 32  | [RFCXXXX] |
-| "\\.//^\\" | CG | ML-KEM-768   | Curve25519  | SHA3-256 | SHAKE-256 | 32    | 32  | [RFCXXXX] |
-| " \| /-\\" | CG | ML-KEM-1024  | P-384       | SHA3-256 | SHAKE-256 | 32    | 32  | [RFCXXXX] |
+| Label          | Fw | PQ Component | T Component | KDF      | PRG       | Nseed | Nss | Reference |
+|================|====|==============|=============|==========|===========|=======|=====|===========|
+| 0x7C2D28292D7C | CG | ML-KEM-768   | P-256       | SHA3-256 | SHAKE-256 | 32    | 32  | [RFCXXXX] |
+| 0x5C2E2F2F5E5C | CG | ML-KEM-768   | Curve25519  | SHA3-256 | SHAKE-256 | 32    | 32  | [RFCXXXX] |
+| 0x207C202F2D5C | CG | ML-KEM-1024  | P-384       | SHA3-256 | SHAKE-256 | 32    | 32  | [RFCXXXX] |
 {: #iana-table title="Hybrid KEM Labels" }
 
 [ RFC EDITOR: Please replace "XXXX" above with the number assigned to this RFC ]


### PR DESCRIPTION
As discussed in #28, there are challenges with special characters in the label strings as written.  This PR removes the ASCII and just presents them as hex strings.