### PR TITLE
Fix (ss, ct) order in test vectors

### DIFF
--- a/reference-implementation/src/test_vectors.rs
+++ b/reference-implementation/src/test_vectors.rs
@@ -45,7 +45,7 @@ impl HybridKemTestVector {
         let seed = vec![index; K::SEED_SIZE];
         let randomness = vec![index.wrapping_add(100); K::RANDOMNESS_SIZE];
         let (dk, ek, info) = K::derive_key_pair(&seed);
-        let (ct, ss) = K::encaps_derand(&ek, &randomness);
+        let (ss, ct) = K::encaps_derand(&ek, &randomness);
 
         HybridKemTestVector {
             seed,


### PR DESCRIPTION
This doesn't result in a change in `test-vectors.json` because that file is out of sync with `main`.  If you generate test vectors on main, they produce the wrong order (`ss` and `ct` are swapped); this PR fixes that bug.